### PR TITLE
Token burn works

### DIFF
--- a/server/access/grantAccess.js
+++ b/server/access/grantAccess.js
@@ -1,8 +1,10 @@
 // server/access/grantAccess.js
 
-const { getConnection } = require("../utilities/dbConnector");
-const logger = require("../utilities/logger");
 require("dotenv").config({ path: "../.env" });
+
+const { getConnection } = require("../utilities/dbConnector");
+
+const logger = require("../utilities/logger");
 
 const { getUserWalletAddress } = require("../access/extractWalletAddress");
 
@@ -17,11 +19,11 @@ async function grantAccess(documentId, targetUser, isProactive = false) {
       : process.env.DB_TABLE_SHARE_ON_REQUEST;
 
     // check for existing share
-    const checkResult = await connection.execute(
-      `SELECT COUNT(*) AS count FROM ${tableName} WHERE DOCUMENT_ID = :documentId AND TARGET_USER = :targetUser`,
+    const sharedDocsCheck = await connection.execute(
+      `SELECT COUNT(*) AS count FROM BCCONV.SHARED_DOCS WHERE DOCUMENT_ID = :documentId AND TARGET_USER = :targetUser`,
       [documentId, targetUser]
     );
-    if (checkResult.rows[0].COUNT > 0) {
+    if (sharedDocsCheck.rows[0].COUNT > 0) {
       logger.info(`Document ${documentId} already shared with ${targetUser}`);
       return;
     }

--- a/server/access/revokeAccess.js
+++ b/server/access/revokeAccess.js
@@ -1,3 +1,57 @@
-// server/access/revokeAccess.js
+require("dotenv").config({ path: "../.env" });
+const logger = require("../utilities/logger");
 
-// to create this later
+const { getConnection } = require("../utilities/dbConnector");
+const { revokeAccessToken } = require("../utilities/smartContractUtils");
+const { getTokenId } = require("./tokenUtils");
+
+async function revokeAccess(documentId, reason) {
+  logger.debug("Starting revokeAccess function");
+  logger.debug(
+    `DB_TABLE_SHARED_DOCS from env:
+    ${process.env.DB_TABLE_SHARED_DOCS}`
+  );
+  logger.debug(`DB_TABLE_REVOKE from env: ${process.env.DB_TABLE_REVOKE}`);
+
+  const tokenId = await getTokenId(documentId);
+  logger.info(`Token ID for revocation: ${tokenId}`);
+  if (!tokenId) {
+    logger.error(`No token found for document ID: ${documentId}`);
+    return;
+  }
+
+  const revokeTime = Math.floor(Date.now() / 1000);
+  const transactionHash = await revokeAccessToken(tokenId);
+  logger.info(`Transaction hash for revocation: ${transactionHash}`);
+
+  let connection;
+  try {
+    connection = await getConnection("user1");
+
+    const revokeQuery = `INSERT INTO CONVTEST.REVOKED_ACCESS (DOCUMENT_ID, REVOKED_TIME, REVOKE_TRANSACTION_HASH, REVOCATION_REASON) VALUES (:documentId, :revokeTime, :transactionHash, :reason)`;
+    logger.debug(`Revocation query: ${revokeQuery}`);
+    await connection.execute(revokeQuery, [
+      documentId,
+      revokeTime,
+      transactionHash,
+      reason,
+    ]);
+
+    const deleteQuery = `DELETE FROM BCCONV.SHARED_DOCS WHERE DOCUMENT_ID = :documentId`;
+    logger.debug(`Delete query: ${deleteQuery}`);
+    await connection.execute(deleteQuery, [documentId]);
+
+    await connection.commit();
+    logger.info(
+      `Revocation and deletion successful for ${documentId}`
+    );
+  } catch (error) {
+    logger.error(`Error in executing revokeAccess: ${error.message}`);
+  } finally {
+    if (connection) {
+      await connection.close();
+    }
+  }
+}
+
+module.exports = { revokeAccess };

--- a/server/access/tokenUtils.js
+++ b/server/access/tokenUtils.js
@@ -1,0 +1,30 @@
+// server/access/tokenUtils.js
+require("dotenv").config({ path: "../.env" });
+const { getConnection } = require("../utilities/dbConnector");
+const logger = require("../utilities/logger");
+
+// get the token ID associated with a given document ID
+async function getTokenId(documentId) {
+  let connection;
+  try {
+    connection = await getConnection("user1");
+    const query = `SELECT ID FROM BCCONV.SHARED_DOCS WHERE document_id = :documentId`;
+    const result = await connection.execute(query, [documentId]);
+
+    if (result.rows.length > 0) {
+      return result.rows[0].ID;
+    } else {
+      logger.info(`No token found for document ID: ${documentId}`);
+      return null;
+    }
+  } catch (error) {
+    logger.error(`Error in getTokenId: ${error.message}`);
+    throw error;
+  } finally {
+    if (connection) {
+      await connection.close();
+    }
+  }
+}
+
+module.exports = { getTokenId };

--- a/server/server.js
+++ b/server/server.js
@@ -10,7 +10,8 @@ const { validateToken } = require("./access/tokenValidation");
 
 const logger = require("../server/utilities/logger");
 const { grantAccess } = require("./access/grantAccess");
-/* const { revokeAccess } = require("./access/revokeAccess"); */
+
+const { revokeAccess } = require("./access/revokeAccess");
 
 const {
   checkSharedDocs,
@@ -59,16 +60,17 @@ app.post("/proactive-share", async (req, res) => {
   }
 });
 
-/* // revoke access
-app.post("/revoke-access", async (req, res) => {
+// endpoint to revoke access
+app.post('/revoke-access', async (req, res) => {
+  const { documentId, reason } = req.body;
+  
   try {
-      const { documentId, reason } = req.body;
-      await revokeAccess(documentId, reason);
-      res.status(200).send(`Access revoked for document ${documentId} with reason: ${reason}`);
+    await revokeAccess(documentId, reason);
+    res.status(200).send('Access revoked');
   } catch (error) {
-      res.status(500).send(`Error revoking access: ${error.message}`);
+    res.status(500).send('Error revoking access');
   }
-}); */
+})
 
 async function startServer() {
   try {

--- a/server/utilities/dbUtils.js
+++ b/server/utilities/dbUtils.js
@@ -27,4 +27,20 @@ async function getDocumentById(document_id, userType) {
   }
 }
 
-module.exports = { getDocumentById };
+async function getExpiredTokens() {
+  let connection;
+  try {
+    connection = await getConnection("user1");
+    const result = await connection.execute(
+      `SELECT token_id FROM ${process.env.DB_TABLE_SHARED_DOCS} WHERE token_expiry < SYSTIMESTAMP`
+    );
+    return result.rows.map(row => row.token_id);
+  } catch (error) {
+    console.error(`Error fetching expired tokens: ${error.message}`);
+    return [];
+  } finally {
+    if (connection) await connection.close();
+  }
+}
+
+module.exports = { getDocumentById, getExpiredTokens };

--- a/server/utilities/pollSharedDocs.js
+++ b/server/utilities/pollSharedDocs.js
@@ -1,13 +1,14 @@
 // server/utilities/pollSharedDocs.js
 
+require("dotenv").config({ path: "../.env" });
 const logger = require("./logger");
 const { getConnection } = require("./dbConnector");
 const { isTokenValid } = require("../access/tokenValidation");
 const { getUserWalletAddress } = require("../access/extractWalletAddress");
-require("dotenv").config({ path: "../.env" });
+
 
 // const POLLING_INTERVAL = 300000; // 5 minutes
-const POLLING_INTERVAL = 20000; // for test only
+const POLLING_INTERVAL = 100000; // for test only
 
 async function checkSharedDocs() {
   let connection;
@@ -34,7 +35,7 @@ async function checkSharedDocs() {
       }
     }
 
-    logger.info(`Valid documents: ${validDocs.join(", ")}`);
+    logger.info(`Valid document(s): ${validDocs.join(", ")}`);
   } catch (error) {
     logger.error(`Database error: ${error.message}`);
   } finally {

--- a/server/utilities/smartContractUtils.js
+++ b/server/utilities/smartContractUtils.js
@@ -40,14 +40,29 @@ async function mintAccessToken(targetUserAddress, documentId, metadataURI) {
   }
 }
 
-// burn NFT to revoke access
+// Burn NFT to revoke access
 async function revokeAccessToken(tokenId) {
   try {
-    const transaction = await contract.revokeAccess(tokenId);
-    await transaction.wait();
+    // Token existence and validity check
+    const isTokenValid = await contract.isTokenValid(tokenId);
+    if (!isTokenValid) {
+      logger.info(`Token ID ${tokenId} is not valid or already revoked.`);
+      return;
+    }
+
+    // Manual gas limit setting
+    const gasLimit = ethers.utils.hexlify(1000000); 
+    const transaction = await contract.revokeAccess(tokenId, {
+      gasLimit: gasLimit
+    });
     logger.info(`Access revoked for token ID ${tokenId}`);
+   
+    const transactionHash = transaction.hash;
+    logger.info(`Revocation transaction hash: ${transactionHash}`);
+    return transactionHash;
   } catch (error) {
     logger.error(`Error revoking access token: ${error.message}`);
+    return null;
   }
 }
 


### PR DESCRIPTION
-- hardcoded table names again...

-- when a token gets burned, the associated document gets deleted from shared_docs

-- a record is created in revoked_access table together with token burn transaction hash, revocation time and reason