### PR TITLE
Contract improvements

### DIFF
--- a/blockchain/contracts/DocumentAccessControl.sol
+++ b/blockchain/contracts/DocumentAccessControl.sol
@@ -1,5 +1,3 @@
-// blockchain/contracts/DocumentAccessControl.sol
-
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
@@ -18,7 +16,8 @@ contract DocumentAccessControl is ERC721, Ownable {
     mapping(bytes32 => Request) public accessRequests;
 
     uint256 private _tokenIds;
-    uint256 public constant DEFAULT_EXPIRATION_PERIOD = 604800; // 7 days in seconds to avoid system being cluttered by pending reqs
+
+    uint256 public constant DEFAULT_EXPIRATION_PERIOD = 259200; // 3 days in seconds to avoid system being cluttered by pending reqs
     uint256 public constant SET_BACKUP_OWNER_TIMELOCK = 18000; // 5 hours timelock before changing to backupOwner
     uint256 private backupOwnerTimelockExpiry;
 
@@ -26,6 +25,7 @@ contract DocumentAccessControl is ERC721, Ownable {
     address private _backupOwner;
 
     enum RequestStatus {
+        None, // default value, used to indicate no request exists
         Pending,
         Approved,
         Rejected
@@ -40,6 +40,7 @@ contract DocumentAccessControl is ERC721, Ownable {
         uint256 requestTime;
         uint256 expirationTime;
         bool isInitialized;
+        uint256 tokenId; // link tokens to requests
     }
 
     // events declaration
@@ -60,8 +61,18 @@ contract DocumentAccessControl is ERC721, Ownable {
 
     event TokenRenewed(uint256 indexed tokenId, uint256 newExpiryTime);
     event TokenExpired(uint256 tokenId);
-    event DocumentAccessed(address user, string documentId, bool accessGranted);
+    event DocumentAccessAttempt(
+        address indexed user,
+        string documentId,
+        bool success,
+        uint256 timestamp
+    );
     event AccessDenied(address user, string documentId, string reason);
+    event UnauthorizedAccessAttempt(
+        address indexed user,
+        string documentId,
+        uint256 tokenId
+    );
 
     event RequestReceived(
         string documentId,
@@ -71,7 +82,8 @@ contract DocumentAccessControl is ERC721, Ownable {
     event RequestUpdated(
         string documentId,
         address approver,
-        RequestStatus status
+        RequestStatus status,
+        string reason
     );
 
     event BackupOwnerChanged(
@@ -80,12 +92,6 @@ contract DocumentAccessControl is ERC721, Ownable {
     );
 
     // MODIFIERS
-
-    // check token existence
-    modifier tokensExist() {
-        require(_tokenIds > 0, "No tokens exist yet");
-        _;
-    }
 
     // restrict access to the owner or the specified user
     modifier onlyOwnerOrUser(address user) {
@@ -108,26 +114,46 @@ contract DocumentAccessControl is ERC721, Ownable {
     //////////////////////////////
 
     // MINT NEW ACCESS TOKEN
+    // allows minting a new access token either in response to an access request
+    // or independently, without a preceding request
     function mintAccess(
         address user,
         string memory documentId,
         string memory documentHash,
         uint256 expiryInSeconds
     ) external onlyOwner returns (uint256) {
-        require(
-            bytes(documentId).length > 0,
-            "Document ID field cannot be empty"
-        );
-        require(
-            expiryInSeconds > 0,
-            "ExbeforenewTokenIdpiry time must be greater than 0"
-        );
+        require(bytes(documentId).length > 0, "Document ID cannot be empty");
+        require(expiryInSeconds > 0, "Expiry time must be positive");
 
         _tokenIds++;
         uint256 newTokenId = _tokenIds;
         _mint(user, newTokenId);
 
-        _tokenExpiryTimes[newTokenId] = block.timestamp + expiryInSeconds; // set custom expiry time
+        bytes32 requestKey = keccak256(abi.encodePacked(documentId, user));
+        Request storage existingRequest = accessRequests[requestKey];
+
+        // check if there is an associated request
+        if (existingRequest.isInitialized) {
+            // if the request is expired, clean it up and revert
+            if (existingRequest.expirationTime < block.timestamp) {
+                delete accessRequests[requestKey];
+                revert("Expired request. Please make a new request.");
+            }
+
+            // ensure the request status is Pending
+            require(
+                existingRequest.status == RequestStatus.Pending,
+                "Request already handled or N/A"
+            );
+
+            // update request status to Approved
+            existingRequest.status = RequestStatus.Approved;
+            existingRequest.approver = msg.sender;
+            existingRequest.tokenId = newTokenId; // link the token to the request
+        }
+
+        // set token data
+        _tokenExpiryTimes[newTokenId] = block.timestamp + expiryInSeconds;
         _documentToTokenId[documentId] = newTokenId;
         _tokenIdToDocumentId[newTokenId] = documentId;
         _setTokenHash(newTokenId, documentHash);
@@ -154,9 +180,7 @@ contract DocumentAccessControl is ERC721, Ownable {
             "Token not yet expired"
         );
 
-        // renew only if token is expired (not revoked)
         _tokenExpiryTimes[tokenId] = block.timestamp + additionalTimeInSeconds;
-
         emit TokenRenewed(tokenId, _tokenExpiryTimes[tokenId]);
     }
 
@@ -165,13 +189,9 @@ contract DocumentAccessControl is ERC721, Ownable {
         uint256 tokenId,
         string memory reason
     ) external onlyOwner {
-        // require reason string
         require(bytes(reason).length > 0, "Must provide reason string");
 
-        // check if token exists
-        require(_tokenExpiryTimes[tokenId] != 0, "Nonexistent token");
-
-        // check expiry status
+        require(_tokenExpiryTimes[tokenId] != 0, "Token does not exist");
         require(
             _tokenExpiryTimes[tokenId] > block.timestamp,
             "Token already expired"
@@ -182,12 +202,17 @@ contract DocumentAccessControl is ERC721, Ownable {
 
         // store the document ID before burning the token
         string memory docId = _tokenIdToDocumentId[tokenId];
+        bytes32 requestKey = keccak256(abi.encodePacked(docId, tokenOwner));
+        if (accessRequests[requestKey].isInitialized) {
+            accessRequests[requestKey].status = RequestStatus.None;
+        }
 
         // revoke access & invalidate token
         _burn(tokenId);
         _tokenExpiryTimes[tokenId] = 0;
 
         // remove document reference and mapping
+
         delete _documentToTokenId[docId];
         delete _tokenIdToDocumentId[tokenId];
 
@@ -198,42 +223,14 @@ contract DocumentAccessControl is ERC721, Ownable {
     // UTILS //
     ///////////
 
-    // TOKEN VALIDITY CHECK
-    function isTokenValid(uint256 tokenId) public returns (bool) {
-        bool isValid = _tokenExpiryTimes[tokenId] > block.timestamp;
-        if (!isValid) {
-            emit TokenExpired(tokenId);
-        }
-        return isValid;
-    }
-
-    // HAS ACCESS
-    // has access to a specific document
-    function hasAccess(
-        address user,
-        string memory documentId
-    ) external onlyOwnerOrUser(user) tokensExist returns (bool) {
-        uint256 tokenId = _documentToTokenId[documentId];
-
-        // check if token exists
-        if (_tokenExpiryTimes[tokenId] == 0) {
-            // denied access, you can provide a standard reason or customize it
-            emit AccessDenied(
-                user,
-                documentId,
-                "Access token does not exist or is expired"
-            );
-            return false;
-        }
-        address owner = ownerOf(tokenId);
-
-        // evaluate access
-        bool hasValidAccess = owner == user && isTokenValid(tokenId);
-
-        // log result
-        emit DocumentAccessed(user, documentId, hasValidAccess);
-
-        return hasValidAccess;
+    // Utility function to check if a request exists and is pending
+    function isRequestPending(
+        string memory documentId,
+        address requester
+    ) public view returns (bool) {
+        bytes32 requestKey = keccak256(abi.encodePacked(documentId, requester));
+        Request memory request = accessRequests[requestKey];
+        return request.isInitialized && request.status == RequestStatus.Pending;
     }
 
     // REQUEST ACCESS
@@ -242,8 +239,27 @@ contract DocumentAccessControl is ERC721, Ownable {
         address requester
     ) external {
         bytes32 requestKey = keccak256(abi.encodePacked(documentId, requester));
-        require(!accessRequests[requestKey].isInitialized, "Request exists");
+        Request storage existingRequest = accessRequests[requestKey];
 
+        // check if the request exists and is initialized
+        if (existingRequest.isInitialized) {
+            // if the request is expired, clean it up
+            if (existingRequest.expirationTime < block.timestamp) {
+                delete accessRequests[requestKey];
+            } else {
+                // if the request is still active (Pending or Approved), revert
+                require(
+                    existingRequest.status != RequestStatus.Approved,
+                    "Access already granted"
+                );
+                require(
+                    existingRequest.status != RequestStatus.Pending,
+                    "Request already pending"
+                );
+            }
+        }
+
+        // create a new request
         accessRequests[requestKey] = Request({
             documentId: documentId,
             requester: requester,
@@ -251,7 +267,8 @@ contract DocumentAccessControl is ERC721, Ownable {
             status: RequestStatus.Pending,
             requestTime: block.timestamp,
             expirationTime: block.timestamp + DEFAULT_EXPIRATION_PERIOD,
-            isInitialized: true
+            isInitialized: true,
+            tokenId: 0 // initialize tokenId with a default value
         });
 
         emit RequestReceived(documentId, requester, RequestStatus.Pending);
@@ -264,18 +281,88 @@ contract DocumentAccessControl is ERC721, Ownable {
         string memory reason
     ) external onlyOwner {
         bytes32 requestKey = keccak256(abi.encodePacked(documentId, requester));
-        Request storage request = accessRequests[requestKey];
+        Request storage existingRequest = accessRequests[requestKey];
 
-        require(request.isInitialized, "Request does not exist");
+        // check if the request is valid for denial
+        require(existingRequest.isInitialized, "Request does not exist");
         require(
-            request.status == RequestStatus.Pending,
-            "Request already handled"
+            existingRequest.status == RequestStatus.Pending,
+            "Request not valid for denial"
         );
 
-        request.status = RequestStatus.Rejected;
-        request.approver = msg.sender;
+        // if the request is expired, clean it up and revert
+        if (existingRequest.expirationTime < block.timestamp) {
+            delete accessRequests[requestKey];
+            revert("Expired request. Please make a new request.");
+        }
 
-        emit AccessDenied(requester, documentId, reason);
+        // proceed with denying the request
+        existingRequest.status = RequestStatus.Rejected;
+        existingRequest.approver = msg.sender;
+        existingRequest.expirationTime =
+            block.timestamp +
+            DEFAULT_EXPIRATION_PERIOD; // set an expiration for the rejection
+
+        emit RequestUpdated(
+            documentId,
+            requester,
+            RequestStatus.Rejected,
+            reason
+        );
+    }
+
+    // TOKEN VALIDITY CHECK
+    function isTokenValid(uint256 tokenId) public returns (bool) {
+        // Check if the token has been minted
+        if (_tokenExpiryTimes[tokenId] == 0) {
+            revert("Token does not exist or has been revoked");
+        }
+
+        bool isValid = _tokenExpiryTimes[tokenId] > block.timestamp;
+        if (!isValid) {
+            emit TokenExpired(tokenId);
+        }
+        return isValid;
+    }
+
+    // internal function to check if a user has access to a specific document
+    // returns true if the user has access, false otherwise
+    function _hasAccess(
+        address user,
+        string memory documentId
+    ) internal returns (bool) {
+        uint256 tokenId = _documentToTokenId[documentId];
+        // check if token exists and is valid
+        return
+            (_tokenExpiryTimes[tokenId] != 0) &&
+            (ownerOf(tokenId) == user) &&
+            isTokenValid(tokenId);
+    }
+
+    // external function to check access to a document
+    // logs the access attempt and returns the access status
+    function hasAccess(
+        address user,
+        string memory documentId
+    ) external returns (bool) {
+        uint256 tokenId = _documentToTokenId[documentId];
+        try this.isTokenValid(tokenId) returns (bool isValid) {
+            if (isValid && ownerOf(tokenId) == user) {
+                return true;
+            }
+        } catch {
+            emit UnauthorizedAccessAttempt(user, documentId, tokenId);
+        }
+        return false;
+    }
+
+    // Internal function to log document access attempts
+    function _logAccessAttempt(
+        address user,
+        string memory documentId,
+        bool success
+    ) internal {
+        emit DocumentAccessAttempt(user, documentId, success, block.timestamp);
     }
 
     // GET ALL TOKEN DATA
@@ -285,12 +372,9 @@ contract DocumentAccessControl is ERC721, Ownable {
     )
         external
         onlyOwner
-        tokensExist
         returns (address owner, uint256 expiryTime, bool isValid)
     {
-        if (_tokenExpiryTimes[tokenId] == 0) {
-            return (address(0), 0, false);
-        }
+        require(_tokenExpiryTimes[tokenId] != 0, "Token does not exist");
 
         owner = ownerOf(tokenId);
         expiryTime = _tokenExpiryTimes[tokenId]; // expiry time from the mapping
@@ -307,7 +391,13 @@ contract DocumentAccessControl is ERC721, Ownable {
         _tokenHashes[tokenId] = documentHash;
     }
 
-    // custom code to force all token transfers via own function which will revert
+    ///////////////
+    // OVERRIDES //
+    ///////////////
+
+    // PREVENT TOKEN TRANSFERS
+    // can't override safeTransfer in ERC721.sol
+    // force all token transfers via own function which will revert
     function customSafeTransferFrom(
         address from,
         address to,
@@ -322,6 +412,20 @@ contract DocumentAccessControl is ERC721, Ownable {
         uint256 tokenId
     ) public override onlyCustomTransfer(from, to, tokenId) {
         // logic won't execute due to modifier revert
+    }
+
+    // override the tokenURI function to remove metadata URI functionality
+    function tokenURI(
+        uint256 tokenId
+    ) public view override(ERC721) returns (string memory) {
+        return _tokenHashes[tokenId];
+    }
+
+    // disable inherited renounceOwnership
+    function renounceOwnership() public view override onlyOwner {
+        revert(
+            "Renouncing ownership is disabled. Try transferring ownership to the backup owner instead."
+        );
     }
 
     // TRANSFER OWNERSHIP TO BACKUP ACC
@@ -347,24 +451,6 @@ contract DocumentAccessControl is ERC721, Ownable {
     function setPendingBackupOwner(address backupOwner) public onlyOwner {
         pendingBackupOwner = backupOwner;
         backupOwnerTimelockExpiry = block.timestamp + SET_BACKUP_OWNER_TIMELOCK;
-    }
-
-    ///////////////
-    // OVERRIDES //
-    ///////////////
-
-    // override the tokenURI function to remove metadata URI functionality
-    function tokenURI(
-        uint256 tokenId
-    ) public view override(ERC721) tokensExist returns (string memory) {
-        return _tokenHashes[tokenId];
-    }
-
-    // disable inherited renounceOwnership
-    function renounceOwnership() public view override onlyOwner {
-        revert(
-            "Renouncing ownership is disabled. Try transferring ownership to the backup owner instead."
-        );
     }
 
     function supportsInterface(


### PR DESCRIPTION
-- tokenIDs are now linked to their requests

-- include None in RequestStatus enum (absence of request)

-- expired events handling: clean up upon demand

-- isRequestPending

-- tightening up all require statements

-- logAccessAttempt function/DicumentAccessAttempt event

-- mintAccess() upon expired token now expects a Request to be in pending status IF a previous, granted request exists. Implement leveraging renewAccess() on backend when a previously accepted request exists

-- new event UnauthorizedAccessAttempt that gets emitted when hasAccess() fails due to invalid token

____________________
Split this into main contract and Audit.sol?